### PR TITLE
Add the upgrade guide for cost management 4.2

### DIFF
--- a/docs/en/architecture.mdx
+++ b/docs/en/architecture.mdx
@@ -1,5 +1,5 @@
 ---
-weight: 15
+weight: 16
 sourceSHA: 65711656e6ba29eeb185fcffd2f18cf12055a3459fd48453eb855133ba7d768d
 ---
 

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -1,0 +1,40 @@
+---
+weight: 15
+---
+
+# Upgrade
+
+:::info
+
+This document provides the upgrade path principles and supported version compatibility for Alauda Container Platform Cost Management.
+
+:::
+
+## Compatibility Matrix
+
+The table below lists supported versions of the Alauda Container Platform Cost Management:
+
+|Cost Management Version|Supported Alauda Container Platform Version|
+|---|---|
+|4.2.0|4.0.x,4.1.x,4.2.x,4.3.x,4.4.x|
+|4.1.8|4.0.x,4.1.x,4.2.x,4.3.x|
+|4.1.7|4.0.x,4.1.x,4.2.x|
+|4.1.6|4.0.x,4.1.x,4.2.x|
+|4.1.x|4.0.x,4.1.x|
+
+## Upgrade Path Guidelines
+
+### Consecutive Upgrade (Recommended)
+- **Description**: Upgrade step-by-step through consecutive minor versions.
+- **Example**: 4.1.x → 4.2.x
+
+### Patch-Level Upgrade
+- **Description**: Upgrades between any patch versions within the same minor version are fully compatible and can be performed directly.
+- **Example**: 4.2.0 → 4.2.x
+
+### Special Upgrade Considerations
+
+For early versions of the Cost Management plugin, the upgrade process is as follows:
+
+- **3.18.x** → **4.1.x**
+- **4.0.x** → **4.1.x**


### PR DESCRIPTION
Carry the upgrade guide over from `release-4.1` into the flattened 4.2 doc layout.

- New `docs/en/upgrade.mdx`: compatibility matrix and upgrade path guidelines.
- Matrix gains a `4.2.0` row (ACP 4.0.x-4.4.x) and a `4.1.8` row (ACP 4.0.x-4.3.x).
- `architecture.mdx` weight 15 -> 16 so upgrade follows installation.

Ref: AIT-73679