### PR TITLE
Target 4.2.x in the early-version upgrade paths

### DIFF
--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -36,5 +36,5 @@ The table below lists supported versions of the Alauda Container Platform Cost M
 
 For early versions of the Cost Management plugin, the upgrade process is as follows:
 
-- **3.18.x** → **4.1.x**
-- **4.0.x** → **4.1.x**
+- **3.18.x** → **4.2.x**
+- **4.0.x** → **4.2.x**


### PR DESCRIPTION
The upgrade page was carried over from `release-4.1` and still pointed the early-version upgrade paths at 4.1.x. Target 4.2.x instead.

Ref: AIT-73679